### PR TITLE
Possible draw image implementation

### DIFF
--- a/examples/4-draw-image.elm
+++ b/examples/4-draw-image.elm
@@ -126,6 +126,5 @@ drawScaledImages drawOps canvas =
                 , Rect (Position 0 0) (Size 800 600)
                 , Stroke
                 ]
-
     in
         Canvas.batch drawOpsWithBorder canvas

--- a/examples/4-draw-image.elm
+++ b/examples/4-draw-image.elm
@@ -1,0 +1,109 @@
+module Main exposing (..)
+
+import Html exposing (..)
+import Canvas exposing (Size, Position, Error, DrawOp(..), DrawImageOp(..), Canvas)
+import Canvas.Events
+import Color exposing (Color)
+import Task
+
+
+main =
+    Html.program
+        { init = ( Loading, loadImage )
+        , view = view
+        , update = update
+        , subscriptions = always Sub.none
+        }
+
+
+
+-- TYPES
+
+
+type Msg
+    = ImageLoaded (Result Error Canvas)
+    | Blit Position
+
+
+type Model
+    = GotCanvas Canvas (List DrawOp)
+    | Loading
+
+
+loadImage : Cmd Msg
+loadImage =
+    Task.attempt
+        ImageLoaded
+        (Canvas.loadImage "./steelix.png")
+
+
+
+-- UPDATE
+
+
+update : Msg -> Model -> ( Model, Cmd Msg )
+update message model =
+    case message of
+        ImageLoaded result ->
+            case Result.toMaybe result of
+                Just canvas ->
+                    ( GotCanvas canvas []
+                    , Cmd.none
+                    )
+
+                Nothing ->
+                    ( Loading
+                    , loadImage
+                    )
+
+        Blit position ->
+            case model of
+                Loading ->
+                    ( Loading
+                    , loadImage
+                    )
+
+                GotCanvas canvas drawOps ->
+                    let
+                        additionalDrawOps : List DrawOp
+                        additionalDrawOps =
+                            [ DrawImage canvas (Scale position (Size 64 64))
+                            ]
+                    in
+                        ( GotCanvas canvas (List.append drawOps additionalDrawOps)
+                        , Cmd.none
+                        )
+
+
+
+-- VIEW
+
+
+view : Model -> Html Msg
+view model =
+    div
+        []
+        [ p [] [ text "Elm-Canvas" ]
+        , presentIfReady model
+        ]
+
+
+presentIfReady : Model -> Html Msg
+presentIfReady model =
+    case model of
+        Loading ->
+            p [] [ text "Loading image" ]
+
+        GotCanvas canvas drawOps ->
+            Canvas.toHtml
+                [ Canvas.Events.onMouseDown Blit ]
+                (drawScaledImages drawOps canvas)
+
+
+drawScaledImages : List DrawOp -> Canvas -> Canvas
+drawScaledImages drawOps canvas =
+    let
+        { width, height } =
+            Canvas.getSize canvas
+    in
+        Canvas.batch drawOps canvas

--- a/src/Canvas.elm
+++ b/src/Canvas.elm
@@ -7,7 +7,7 @@ module Canvas
         , DrawOp(..)
         , CompositeOp(..)
         , Cap(..)
-        , DrawImageOp(..)
+        , DrawImageParams(..)
         , initialize
         , toHtml
         , batch
@@ -76,7 +76,7 @@ type DrawOp
     | FillStyle Color
     | BeginPath
     | PutImageData (Array Int) Size Position
-    | DrawImage Canvas DrawImageOp
+    | DrawImage Canvas DrawImageParams
 
 
 type CompositeOp
@@ -113,10 +113,10 @@ type Cap
     | Square
 
 
-type DrawImageOp
+type DrawImageParams
     = At Position
-    | Scale Position Size
-    | CropScale Position Size Position Size
+    | Scaled Position Size
+    | CropScaled Position Size Position Size
 
 
 {-| `initialize` takes in a width and a height (both type `Int`), and returns a `Canvas` with that width and height. A freshly initialized `Canvas` is entirely transparent (its data is an array of 0s, that has a length of width x height x 4)

--- a/src/Canvas.elm
+++ b/src/Canvas.elm
@@ -7,6 +7,7 @@ module Canvas
         , DrawOp(..)
         , CompositeOp(..)
         , Cap(..)
+        , DrawImageOp(..)
         , initialize
         , toHtml
         , batch
@@ -75,6 +76,7 @@ type DrawOp
     | FillStyle Color
     | BeginPath
     | PutImageData (Array Int) Size Position
+    | DrawImage Canvas DrawImageOp
 
 
 type CompositeOp
@@ -109,6 +111,12 @@ type Cap
     = Butt
     | Round
     | Square
+
+
+type DrawImageOp
+    = At Position
+    | Scale Position Size
+    | CropScale Position Size Position Size
 
 
 {-| `initialize` takes in a width and a height (both type `Int`), and returns a `Canvas` with that width and height. A freshly initialized `Canvas` is entirely transparent (its data is an array of 0s, that has a length of width x height x 4)

--- a/src/Canvas/Events.elm
+++ b/src/Canvas/Events.elm
@@ -1,5 +1,5 @@
-module Canvas.Events 
-    exposing 
+module Canvas.Events
+    exposing
         ( onMouseDown
         , onMouseUp
         , onMouseMove

--- a/src/Native/Canvas.js
+++ b/src/Native/Canvas.js
@@ -200,7 +200,7 @@ var _elm_community$canvas$Native_Canvas = function () {
             )
             break;
 
-          case "Scale":
+          case "Scaled":
 
             var destPosition = drawImageOp._0
             var destSize = drawImageOp._1
@@ -211,7 +211,7 @@ var _elm_community$canvas$Native_Canvas = function () {
             )
             break;
 
-          case "CropScale":
+          case "CropScaled":
 
             var srcPosition = drawImageOp._0
             var srcSize = drawImageOp._1

--- a/src/Native/Canvas.js
+++ b/src/Native/Canvas.js
@@ -165,10 +165,12 @@ var _elm_community$canvas$Native_Canvas = function () {
         break;
 
       case "Fill" :
+
         ctx.fill();
         break;
 
       case "PutImageData" :
+
         var position = drawOp._2;
         var size = drawOp._1;
         var data = _elm_lang$core$Native_Array.toJSArray(drawOp._0);
@@ -180,6 +182,51 @@ var _elm_community$canvas$Native_Canvas = function () {
         }
 
         ctx.putImageData(imageData, position.x, position.y);
+        break;
+
+      case "DrawImage":
+
+        var srcCanvas = drawOp._0.canvas()
+        var drawImageOp = drawOp._1
+
+        switch (drawOp._1.ctor) {
+          case "At":
+
+            var destPosition = drawImageOp._0
+            ctx.drawImage(
+              srcCanvas,
+              destPosition.x,
+              destPosition.y
+            )
+            break;
+
+          case "Scale":
+
+            var destPosition = drawImageOp._0
+            var destSize = drawImageOp._1
+            ctx.drawImage(
+              srcCanvas,
+              destPosition.x, destPosition.y,
+              destSize.width, destSize.height
+            )
+            break;
+
+          case "CropScale":
+
+            var srcPosition = drawImageOp._0
+            var srcSize = drawImageOp._1
+            var destPosition = drawImageOp._2
+            var destSize = drawImageOp._3
+            ctx.drawImage(
+              srcCanvas,
+              srcPosition.x, srcPosition.y,
+              srcSize.width, srcSize.height,
+              destPosition.x, destPosition.y,
+              destSize.width, destSize.height
+            )
+            break
+        }
+
         break;
     }
   }


### PR DESCRIPTION
# NOTE:

This is just a possible implementation. It doesn't have to be merged if you're unhappy with it, but I just wanted to experiment a little. I'm especially not happy with `DrawImageOp.At`...I'd like a better name, but I don't know what that is yet.

## What

 - Summary, creates a near 1-1 DrawImage implementation from the javascript function without creating multiple DrawOps (arguably).
 - Adds `DrawImage Canvas DrawImageOp` to `DrawOp`
 - Created `At Position`, `Scale Position Size` and `CropScale Position Size Position Size` in `DrawImageOp` union type.
 - Added an example `4-draw-image.elm` that uses DrawImage.

## Why

 - [The bottom bit of my comment from this trello card](https://trello.com/c/vjgxvsSf/16-for-drawimage-what-should-the-elm-type-be-called)

## GIF

![](https://media.giphy.com/media/7VXZnMTVLvWak/giphy.gif)