### PR TITLE
Version 0.3.1 not recognized by elm-github-install

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.2.0",
+    "version": "0.3.1",
     "summary": "The canvas API in Elm",
     "repository": "https://github.com/elm-canvas/elm-canvas.git",
     "license": "BSD3",
@@ -7,7 +7,7 @@
         "src"
     ],
     "exposed-modules": [
-        "Canvas",
+        "Canvas"
     ],
     "native-modules": true,
     "dependencies": {

--- a/elm-package.json
+++ b/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.3.1",
+    "version": "0.3.2",
     "summary": "The canvas API in Elm",
     "repository": "https://github.com/elm-canvas/elm-canvas.git",
     "license": "BSD3",


### PR DESCRIPTION
Fixed the elm-package.json so that elm-github-install can resolve the 0.3.x version.
I increased the version to 0.3.2 already so you do not have to overwrite a tag.
